### PR TITLE
System: core: do not start cameraserver on zygone init

### DIFF
--- a/rootdir/init.zygote32.rc
+++ b/rootdir/init.zygote32.rc
@@ -7,7 +7,6 @@ service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-sys
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
     onrestart restart audioserver
-    onrestart restart cameraserver
     onrestart restart media
     onrestart restart netd
     onrestart restart wificond

--- a/rootdir/init.zygote32_64.rc
+++ b/rootdir/init.zygote32_64.rc
@@ -7,7 +7,6 @@ service zygote /system/bin/app_process32 -Xzygote /system/bin --zygote --start-s
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
     onrestart restart audioserver
-    onrestart restart cameraserver
     onrestart restart media
     onrestart restart netd
     onrestart restart wificond

--- a/rootdir/init.zygote64.rc
+++ b/rootdir/init.zygote64.rc
@@ -7,7 +7,6 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
     onrestart restart audioserver
-    onrestart restart cameraserver
     onrestart restart media
     onrestart restart netd
     onrestart restart wificond

--- a/rootdir/init.zygote64_32.rc
+++ b/rootdir/init.zygote64_32.rc
@@ -7,7 +7,6 @@ service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-s
     onrestart write /sys/android_power/request_state wake
     onrestart write /sys/power/state on
     onrestart restart audioserver
-    onrestart restart cameraserver
     onrestart restart media
     onrestart restart netd
     onrestart restart wificond


### PR DESCRIPTION
Because we are going to remove cameraserver package